### PR TITLE
gitignore merlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 *.native
 *.byte
 *.install
+.merlin

--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,0 @@
-PKG cmdliner uchar bytes
-S src
-S test
-B _build/**


### PR DESCRIPTION
Dune generates the merlin files, so we can remove the one at the root and add it to gitignore

We're vendoring uutf in ocaml-lsp, and the generated .merlin makes the submodule dirty everytime we build 